### PR TITLE
#4: Configura build heroku para multiprojetos

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,3 +35,5 @@ task stopRunningJar(type: Exec) {
 
     commandLine "${rootDir}/scripts/local-test-server", "stop", "$buildDir/libs/app.jar", "$buildDir"
 }
+
+build.mustRunAfter('clean')

--- a/build.gradle
+++ b/build.gradle
@@ -5,3 +5,21 @@ idea {
         downloadSources = true
     }
 }
+
+task copyToLib(type: Copy) {
+    group = ' >>> HEROKU'
+    description = """
+    Move o jar da aplicacao (gerado pela task build) para a pasta raiz do projeto, que eh utilizada pelo Heroku
+    para executar a aplicacao.
+    """
+    from "${project(':app').buildDir}/libs/"
+    into "$rootDir/build/libs/"
+}
+
+task stage {
+    group = ' >>> HEROKU'
+    description = 'Task utilizada pelo Heroku para construi o jar da aplicacao antes de executa-lo.'
+    dependsOn = [':app:clean', ':app:build', 'copyToLib']
+}
+
+copyToLib.mustRunAfter(':app:build')


### PR DESCRIPTION
O Heroku possui um esquema de buildpacks, que são scripts responsáveis por construir um executável da aplicação e, posteriormente, executar tal executável. 

Geralmente, esses buildpacks são inteligentes o suficiente para identificar o tipo de projeto que estamos utilizando (se é um projeto Java que usa Gradle e Spring Boot, por exemplo). Como passamos a utilizar múltiplos projetos no Gradle, o Buildpack do Heroku deixou de entender nosso projeto como sendo um projeto Gradle com Spring Boot.

Para corrigir isso, precisamos decalarar algumas `tasks` no nosso arquivo de build para que o Heroku volte a entender nossa aplicação corretamente. Para mais detalhes sobre isso, [veja essa página da documentação do Heroku](https://devcenter.heroku.com/articles/deploying-gradle-apps-on-heroku).

Se você quer saber mais sobre como Buildpacks funcionam, veja [esta página aqui](https://devcenter.heroku.com/articles/buildpacks#setting-a-buildpack-on-an-application).

