### PR TITLE
#4: Corrige ordem dos jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ jobs:
   integration-functional-tests:
     docker:
       - image: cypress/base:8
-      - image: aceleradoratw/esqueleto-ci-runner
 
     working_directory: ~/repo
 
@@ -104,7 +103,7 @@ workflows:
             - build
       - integration-deploy:
           requires:
-            - build
+            - functional-tests
           filters:
             branches:
               only: master


### PR DESCRIPTION
Os jobs do workflow do Circle CI estão numa ordem incorreta:

![screenshot from 2018-09-17 12-12-48](https://user-images.githubusercontent.com/4705127/45632211-246e1680-ba73-11e8-9123-2571568ed20a.png)

Idealmente, o deploy para integração só deve acontecer depois que os testes funcionais foram executados corretamente.

Essa PR corrige a ordem:

![screenshot from 2018-09-17 12-18-28](https://user-images.githubusercontent.com/4705127/45632494-d3125700-ba73-11e8-9ec7-ce418f81ea73.png)
