### PR TITLE
16/configuracoes por profile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar build/libs/app.jar
+web: java -jar -Dspring.profiles.active=heroku build/libs/app.jar

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar -Dspring.profiles.active=heroku build/libs/app.jar
+web: java -jar -Dspring.profiles.active=heroku app/build/libs/app.jar

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,7 @@ buildscript {
     }
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
-        classpath "org.postgresql:postgresql:42.2.5"
     }
-}
-
-plugins {
-    id "org.flywaydb.flyway" version "5.1.4"
 }
 
 apply plugin: 'java'
@@ -24,6 +19,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-thymeleaf:${springBootVersion}"
     compile "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
     compile "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
+    compile "org.flywaydb:flyway-core"
     compile "com.h2database:h2"
     compile "org.postgresql:postgresql:42.2.5"
 
@@ -45,17 +41,6 @@ task stopRunningJar(type: Exec) {
     description = "Para aplicacao que foi iniciada por :app:startFromJar"
 
     commandLine "${rootDir}/scripts/local-test-server", "stop", "$buildDir/libs/app.jar", "$buildDir"
-}
-
-flyway {
-
-    def host = System.getenv("ESQUELETO_DB_HOST") ?: 'localhost'
-    def port = System.getenv("ESQUELETO_DB_PORT") ?: 5432
-    def name = System.getenv("ESQUELETO_DB_NAME") ?: 'esqueleto'
-
-    url = "jdbc:postgresql://$host:$port/$name"
-    user = System.getenv("ESQUELETO_DB_USER") ?: 'postgres'
-    password = System.getenv("ESQUELETO_DB_PASSWORD") ?: 'esqueleto'
 }
 
 bootRun {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,4 +58,12 @@ flyway {
     password = System.getenv("ESQUELETO_DB_PASSWORD") ?: 'esqueleto'
 }
 
+bootRun {
+  def activeProfiles = 'dev'
+
+  jvmArgs = [
+    "-Dspring.profiles.active=$activeProfiles"
+  ]
+}
+
 build.mustRunAfter('clean')

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/esqueleto
+    username: postgres
+    password: esqueleto

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -1,6 +1,5 @@
 spring:
   datasource:
-    driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/esqueleto
     username: postgres
     password: esqueleto

--- a/app/src/main/resources/application-heroku.yml
+++ b/app/src/main/resources/application-heroku.yml
@@ -1,0 +1,9 @@
+server:
+  port: ${PORT}
+
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -1,13 +1,4 @@
-server:
-  port: ${PORT:8080}
-
 spring:
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${ESQUELETO_DB_HOST:localhost}:${ESQUELETO_DB_PORT:5432}/${ESQUELETO_DB_NAME:esqueleto}
-    username: ${ESQUELETO_DB_USER:postgres}
-    password: ${ESQUELETO_DB_PASSWORD:esqueleto}
-
   jpa:
     show-sql: true
     database-platform: org.hibernate.dialect.PostgreSQL95Dialect
@@ -19,4 +10,3 @@ spring:
         jdbc:
           lob:
             non_contextual_creation: true
-

--- a/build.gradle
+++ b/build.gradle
@@ -9,5 +9,3 @@ idea {
 task stage {
     dependsOn = [':app:clean', ':app:build']
 }
-
-copyToLib.mustRunAfter(':app:build')

--- a/build.gradle
+++ b/build.gradle
@@ -6,21 +6,8 @@ idea {
     }
 }
 
-task copyToLib(type: Copy) {
-    group = ' >>> HEROKU'
-    description = """
-    Move o jar da aplicacao (gerado pela task build) para a pasta raiz do projeto, que eh utilizada pelo Heroku
-    para executar a aplicacao.
-    """
-    from "${project(':app').buildDir}/libs/"
-    into "$rootDir/build/libs/"
-}
-
 task stage {
-    group = ' >>> HEROKU'
-    description = 'Task utilizada pelo Heroku para construi o jar da aplicacao antes de executa-lo.'
-    dependsOn = [':app:clean', ':app:build', 'copyToLib']
+    dependsOn = [':app:clean', ':app:build']
 }
 
 copyToLib.mustRunAfter(':app:build')
-stage.finalizedBy(':app:flywayMigrate')


### PR DESCRIPTION
  - a17997c: Separa configurações nos perfis `default`, `dev` e `heroku`
    - Para cada perfil, temos um arquivo `application-{perfil}.yml`
    - O perfil `default` se chama somente `application.yml`
    - Por padrão, o Spring fará a mescla das configurações que estão no `default` com o perfil escolhido durante a execução da aplicação. Em outras palavras, o perfil default terá valores padrão para configurações.
  - 14aba8d: Configura `bootRun` para utilizar perfil `dev`
  - 618eac8: Configura Heroku para utilizar perfil `heroku`
  - f0b4aca: Executa migrações automaticamente ao iniciar aplicação

Utiliza as variáveis do Heroku para configurar acesso ao banco. Mais detalhes sobre isto [nesta página](https://devcenter.heroku.com/articles/deploying-spring-boot-apps-to-heroku#connecting-to-a-database).